### PR TITLE
Use tcp instead of tcp4

### DIFF
--- a/core/conn/conn.go
+++ b/core/conn/conn.go
@@ -36,7 +36,7 @@ func NewTCPConn(addr string, timeout time.Duration) (*Conn, error) {
 		DualStack: false,
 		Timeout:   timeout,
 	}
-	c, err := d.Dial("tcp4", addr)
+	c, err := d.Dial("tcp", addr)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func NewTLSConn(addr string, tlsCfg *tls.Config, timeout time.Duration) (*Conn, 
 		DualStack: false,
 		Timeout:   timeout,
 	}
-	c, err := tls.DialWithDialer(&d, "tcp4", addr, tlsCfg)
+	c, err := tls.DialWithDialer(&d, "tcp", addr, tlsCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/core/conn/mockserver.go
+++ b/core/conn/mockserver.go
@@ -27,7 +27,7 @@ type MockPulsarServer struct {
 }
 
 func NewMockPulsarServer(ctx context.Context) (*MockPulsarServer, error) {
-	l, err := net.ListenTCP("tcp4", &net.TCPAddr{
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   net.IPv4zero,
 		Port: 0,
 	})

--- a/core/srv/server.go
+++ b/core/srv/server.go
@@ -30,7 +30,7 @@ import (
 // NewServer returns a ready-to-use Pulsar test server.
 // The server will be closed when the context is canceled.
 func NewServer(ctx context.Context) (*Server, error) {
-	l, err := net.ListenTCP("tcp4", &net.TCPAddr{
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   net.IPv4zero,
 		Port: 0, // Let the OS pick a random free port
 	})


### PR DESCRIPTION
I tried to run client on ipv6-only server, and `tcp4` option for `net.Dialer` breaks connection.